### PR TITLE
Fix syntax of URL for maven cookbook

### DIFF
--- a/common/Berksfile
+++ b/common/Berksfile
@@ -36,4 +36,4 @@ cookbook 'openoffice',              git: 'git://github.com/dhartford/chef-openof
 cookbook 'alfresco',                git: 'git://github.com/maoo/chef-alfresco.git'
 cookbook 'artifact-deployer',       git: 'git://github.com/maoo/artifact-deployer.git',  tag: 'v0.8.6'
 cookbook 'tomcat',                  git: 'git://github.com/maoo/tomcat.git'
-cookbook 'maven',                   git: 'git://github.com:maoo/maven.git'
+cookbook 'maven',                   git: 'git://github.com/maoo/maven.git'


### PR DESCRIPTION
create-vendor-cookbooks.sh was failing with error:

    fatal: Unable to look up github.com (port maoo) (nodename nor servname provided, or not known)